### PR TITLE
Bump Yarn version and refactor VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,20 +12,20 @@
     "javascriptreact",
     "typescript",
     "typescriptreact",
-    "json",
+    "json"
   ],
   "eslint.validate": [
     "javascript",
     "javascriptreact",
     "typescript",
     "typescriptreact",
-    "json",
+    "json"
   ],
 
   // Lock VSCode typescript version to project typescript
   "typescript.check.npmIsInstalled": true,
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false
 }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
 enableGlobalCache: false
 
 nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-4.5.1.cjs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raenonx-pokemon/cms-client",
   "description": "JS / TS client for Strapi Rest API",
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.14.1",
   "version": "1.0.0",
   "private": true,
   "author": "Karthikeyan Mariappan",


### PR DESCRIPTION
Update the Yarn version to 4.14.1 and streamline VSCode settings for improved consistency and clarity.